### PR TITLE
fix/#4: 순환 의존 해결 위해 생성자 주입 -> 메서드 주입으로 변경

### DIFF
--- a/src/main/java/com/dataury/soloJ/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/dataury/soloJ/global/config/WebSecurityConfig.java
@@ -41,14 +41,9 @@ public class WebSecurityConfig {
     @Autowired
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Autowired
-    private CustomOAuth2UserService customOAuth2UserService;
-
-    @Autowired
-    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-
     @Bean
-    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http, CustomOAuth2UserService customOAuth2UserService,
+                                                          OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable);
         http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
         http.httpBasic(basic -> basic.disable());

--- a/src/main/java/com/dataury/soloJ/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/dataury/soloJ/global/security/oauth/CustomOAuth2UserService.java
@@ -4,7 +4,6 @@ import com.dataury.soloJ.domain.user.entity.User;
 import com.dataury.soloJ.domain.user.entity.status.Role;
 import com.dataury.soloJ.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -23,7 +22,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
 
-    private final @Lazy PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
 
     @Override

--- a/src/main/java/com/dataury/soloJ/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/dataury/soloJ/global/security/oauth/CustomOAuth2UserService.java
@@ -4,7 +4,7 @@ import com.dataury.soloJ.domain.user.entity.User;
 import com.dataury.soloJ.domain.user.entity.status.Role;
 import com.dataury.soloJ.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.internal.util.stereotypes.Lazy;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;


### PR DESCRIPTION
## 🎋 관련 이슈

- #4

## ⚡️ 작업동기

- Spring Security 설정 클래스(WebSecurityConfig)에서 CustomOAuth2UserService와 PasswordEncoder 사이에 순환 의존이 발생하여 애플리케이션이 실행되지 않는 문제가 발생
- 해당 문제는 Spring에서 BeanCurrentlyInCreationException 예외를 발생시키며, 순환 참조로 인해 특정 Bean을 생성할 수 없는 상태로 이어

이를 해결하기 위해 불필요한 필드 주입을 제거하고, 메서드 파라미터 주입 방식을 적용하여 의존성 생성 시점을 명확히 조절하도록 수정하였습니다.

## 🔑 주요 변경사항

- WebSecurityConfig 클래스에서 CustomOAuth2UserService, OAuth2LoginSuccessHandler 등에 대한 필드 주입을 제거
- SecurityFilterChain Bean 메서드의 메서드 파라미터로 의존성 주입되도록 구조를 변경
- Spring이 SecurityFilterChain Bean을 생성할 때 필요한 객체만 해당 시점에 주입되므로, 순환 참조가 발생하지 않도록 설계
- 기존 @Lazy 방식으로 PasswordEncoder 순환 참조를 해결하려 했으나, 주입 시점 자체가 잘못되어 근본적인 해결이 되지 않음을 확인
- PasswordEncoder는 @Bean 메서드로 정의하고, 다른 컴포넌트에서는 이를 필요 시 주입받도록 설계


## 💡 유의사항 또는 기타

-Spring Security 설정 클래스에서 의존성 주입 시에는 가급적 필드 주입이 아닌 메서드 주입 방식을 사용하는 것이 순환 의존을 방지하고, 초기화 순서를 명확히 하기에 적합
- @Lazy는 순환 의존 해결의 보조 수단일 뿐이며, 순환 구조 자체를 끊는 것이 더 근본적인 해결 방법
- SecurityFilterChain Bean의 파라미터에 필요한 컴포넌트들을 주입받는 방식은 Spring Security 공식 문서에서도 권장되는 설계

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!