### PR TITLE
feat: 사용자 인증/인가 기능 구현 및 테스트

### DIFF
--- a/src/main/java/com/dataury/soloJ/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/controller/ChatRoomController.java
@@ -34,25 +34,22 @@ public class ChatRoomController {
     @Operation(summary = "관광지 기반 채팅방 생성", description = "관광지 기반 동행 채팅방을 생성합니다. 생성한 사용자가 자동으로 방장이 됩니다.")
     @PostMapping("/create")
     public ApiResponse<ChatRoomResponseDto.CreateChatRoomResponse> createChatRoom(
-            @Parameter(hidden = true) @AuthUser Long userId,
             @RequestBody ChatRoomRequestDto.CreateChatRoomDto request) {
-        return ApiResponse.onSuccess(chatRoomCommandService.createChatRoom(request, userId));
+        return ApiResponse.onSuccess(chatRoomCommandService.createChatRoom(request));
     }
 
     @Operation(summary = "채팅방 참가", description = "사용자가 채팅방에 참가합니다.")
     @PostMapping("/{roomId}/join")
     public ApiResponse<ChatRoomResponseDto.JoinChatRoomResponse> joinChatRoom(
-            @Parameter(hidden = true) @AuthUser Long userId,
             @PathVariable Long roomId) {
-        return ApiResponse.onSuccess(chatRoomCommandService.joinChatRoom(roomId, userId));
+        return ApiResponse.onSuccess(chatRoomCommandService.joinChatRoom(roomId));
     }
 
     @Operation(summary = "채팅방 나가기", description = "사용자가 채팅방에서 나갑니다.")
     @DeleteMapping("/{roomId}/leave")
     public ApiResponse<String> leaveChatRoom(
-            @Parameter(hidden = true) @AuthUser Long userId,
             @PathVariable Long roomId) {
-        chatRoomCommandService.leaveChatRoom(roomId, userId);
+        chatRoomCommandService.leaveChatRoom(roomId);
         return ApiResponse.onSuccess("채팅방에서 성공적으로 나갔습니다.");
     }
 

--- a/src/main/java/com/dataury/soloJ/domain/chat/service/ChatRoomCommandService.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/service/ChatRoomCommandService.java
@@ -15,6 +15,7 @@ import com.dataury.soloJ.domain.user.repository.UserProfileRepository;
 import com.dataury.soloJ.domain.user.repository.UserRepository;
 import com.dataury.soloJ.global.code.status.ErrorStatus;
 import com.dataury.soloJ.global.exception.GeneralException;
+import com.dataury.soloJ.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,7 +62,8 @@ public class ChatRoomCommandService {
 
     // 채팅방 나가기
     @Transactional
-    public void leaveChatRoom(Long chatRoomId, Long userId) {
+    public void leaveChatRoom(Long chatRoomId) {
+        Long userId = SecurityUtils.getCurrentUserId();
         removeUserFromChatRoom(chatRoomId, userId);
     }
 
@@ -88,7 +90,9 @@ public class ChatRoomCommandService {
 
     // 관광지 기반 채팅방 생성
     @Transactional
-    public ChatRoomResponseDto.CreateChatRoomResponse createChatRoom(ChatRoomRequestDto.CreateChatRoomDto request, Long userId) {
+    public ChatRoomResponseDto.CreateChatRoomResponse createChatRoom(ChatRoomRequestDto.CreateChatRoomDto request) {
+        Long userId = SecurityUtils.getCurrentUserId();
+
         // 관광지 조회
         TouristSpot touristSpot = touristSpotRepository.findById(request.getContentId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.TOURIST_SPOT_NOT_FOUND));
@@ -123,7 +127,9 @@ public class ChatRoomCommandService {
 
     // 채팅방 참가
     @Transactional
-    public ChatRoomResponseDto.JoinChatRoomResponse joinChatRoom(Long chatRoomId, Long userId) {
+    public ChatRoomResponseDto.JoinChatRoomResponse joinChatRoom(Long chatRoomId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+
         // 채팅방 조회
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHATROOM_NOT_FOUND));

--- a/src/main/java/com/dataury/soloJ/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/dataury/soloJ/domain/mypage/controller/MyPageController.java
@@ -3,8 +3,7 @@ package com.dataury.soloJ.domain.mypage.controller;
 import com.dataury.soloJ.domain.chat.dto.ChatRoomListItem;
 import com.dataury.soloJ.domain.mypage.service.MyPageFacadeService;
 import com.dataury.soloJ.global.ApiResponse;
-import com.dataury.soloJ.global.auth.AuthUser;
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +21,8 @@ public class MyPageController {
     private final MyPageFacadeService myPageFacadeService;
 
     @GetMapping("/chatrooms")
-    public ApiResponse<List<ChatRoomListItem>> getMyChatRooms(@Parameter(hidden = true) @AuthUser Long userId) {
-        return ApiResponse.onSuccess(myPageFacadeService.getMyChatRooms(userId));
+    @Operation(summary = "사용자 동행방 목록 조회")
+    public ApiResponse<List<ChatRoomListItem>> getMyChatRooms() {
+        return ApiResponse.onSuccess(myPageFacadeService.getMyChatRooms());
     }
 }

--- a/src/main/java/com/dataury/soloJ/domain/mypage/service/MyPageFacadeService.java
+++ b/src/main/java/com/dataury/soloJ/domain/mypage/service/MyPageFacadeService.java
@@ -2,6 +2,7 @@ package com.dataury.soloJ.domain.mypage.service;
 
 import com.dataury.soloJ.domain.chat.dto.ChatRoomListItem;
 import com.dataury.soloJ.domain.chat.service.ChatRoomQueryService;
+import com.dataury.soloJ.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,11 +17,13 @@ public class MyPageFacadeService {
     // private final ArticleQueryService articleQueryService;
     // private final CommentQueryService commentQueryService;
 
-    public List<ChatRoomListItem> getMyChatRooms(Long userId) {
+    public List<ChatRoomListItem> getMyChatRooms() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        System.out.println("User id: " + userId);
         return chatRoomQueryService.getMyChatRooms(userId);
     }
 
     // 앞으로 확장:
-    // public List<MyArticleDto> getMyArticles(Long userId, Pageable pageable) { ... }
-    // public List<MyCommentDto> getMyComments(Long userId, Pageable pageable) { ... }
+    // public List<MyArticleDto> getMyArticles( Pageable pageable) { ... }
+    // public List<MyCommentDto> getMyComments( Pageable pageable) { ... }
 }

--- a/src/main/java/com/dataury/soloJ/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/dataury/soloJ/domain/plan/controller/PlanController.java
@@ -31,27 +31,27 @@ public class PlanController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    private ApiResponse<PlanResponseDto.planDto> newPlan (@Parameter(hidden = true) @AuthUser Long userId, @RequestBody CreatePlanDto planRequestDto){
-        return ApiResponse.onSuccess(planService.createPlan(userId, planRequestDto));
+    private ApiResponse<PlanResponseDto.planDto> newPlan (@RequestBody CreatePlanDto planRequestDto){
+        return ApiResponse.onSuccess(planService.createPlan(planRequestDto));
     }
 
     @PatchMapping("/{planId}")
     @Operation(summary = "계획 수정", description = "계획 정보를 수정합니다. 토큰 필요.")
     public ApiResponse<PlanResponseDto.planDto> updatePlan(
-            @Parameter(hidden = true) @AuthUser Long userId,
+            
             @PathVariable Long planId,
             @RequestBody CreatePlanDto dto
     ) {
-        return ApiResponse.onSuccess(planService.updatePlan(userId, planId, dto));
+        return ApiResponse.onSuccess(planService.updatePlan(planId, dto));
     }
 
     @DeleteMapping("/{planId}")
     @Operation(summary = "계획 삭제", description = "계획 정보를 삭제합니다. 토큰 필요.")
     public ApiResponse<Void> deletePlan(
-            @Parameter(hidden = true) @AuthUser Long userId,
+            
             @PathVariable Long planId
     ) {
-        planService.deletePlan(userId, planId);
+        planService.deletePlan(planId);
         return ApiResponse.onSuccess(null);  // 성공 응답만 반환
     }
 

--- a/src/main/java/com/dataury/soloJ/domain/plan/service/PlanService.java
+++ b/src/main/java/com/dataury/soloJ/domain/plan/service/PlanService.java
@@ -13,6 +13,7 @@ import com.dataury.soloJ.domain.user.entity.User;
 import com.dataury.soloJ.domain.user.repository.UserRepository;
 import com.dataury.soloJ.global.code.status.ErrorStatus;
 import com.dataury.soloJ.global.exception.GeneralException;
+import com.dataury.soloJ.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +33,9 @@ public class PlanService {
 
 
     @Transactional
-    public PlanResponseDto.planDto createPlan(Long userId, CreatePlanDto dto) {
+    public PlanResponseDto.planDto createPlan(CreatePlanDto dto) {
+        Long userId = SecurityUtils.getCurrentUserId();
+
         if (dto.getStartDate().isAfter(dto.getEndDate())) {
             throw new GeneralException(ErrorStatus.INVALID_PLAN_DATE);
         }
@@ -73,7 +76,9 @@ public class PlanService {
 
 
     @Transactional
-    public PlanResponseDto.planDto updatePlan(Long userId, Long planId, CreatePlanDto dto) {
+    public PlanResponseDto.planDto updatePlan( Long planId, CreatePlanDto dto) {
+        Long userId = SecurityUtils.getCurrentUserId();
+
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PLAN_NOT_FOUND));
 
@@ -120,7 +125,9 @@ public class PlanService {
 
 
     @Transactional
-    public void deletePlan(Long userId, Long planId) {
+    public void deletePlan(Long planId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PLAN_NOT_FOUND));
 

--- a/src/main/java/com/dataury/soloJ/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dataury/soloJ/domain/user/controller/AuthController.java
@@ -84,8 +84,8 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public ApiResponse<String> logout(@Parameter(hidden = true) @AuthUser Long userId) {
-        authService.logout(userId);
+    public ApiResponse<String> logout() {
+        authService.logout();
         return ApiResponse.onSuccess("로그아웃 완료");
     }
 
@@ -97,8 +97,8 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public ApiResponse<AuthResponseDTO.SignResponseDTO> kakaoProfile(@Parameter(hidden = true) @AuthUser Long userId, @RequestBody AuthRequestDTO.KakaoRequestDTO kakaoRequestDTO) {
-        return ApiResponse.onSuccess(authService.setProfile(userId, kakaoRequestDTO));
+    public ApiResponse<AuthResponseDTO.SignResponseDTO> kakaoProfile( @RequestBody AuthRequestDTO.KakaoRequestDTO kakaoRequestDTO) {
+        return ApiResponse.onSuccess(authService.setProfile(kakaoRequestDTO));
     }
 
     @GetMapping("/check-email")

--- a/src/main/java/com/dataury/soloJ/domain/user/service/AuthService.java
+++ b/src/main/java/com/dataury/soloJ/domain/user/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.dataury.soloJ.domain.user.service;
 
-
 import com.dataury.soloJ.domain.user.converter.AuthConverter;
 import com.dataury.soloJ.domain.user.dto.AuthRequestDTO;
 import com.dataury.soloJ.domain.user.dto.AuthResponseDTO;
@@ -13,6 +12,7 @@ import com.dataury.soloJ.domain.user.repository.UserProfileRepository;
 import com.dataury.soloJ.domain.user.repository.UserRepository;
 import com.dataury.soloJ.global.code.status.ErrorStatus;
 import com.dataury.soloJ.global.exception.GeneralException;
+import com.dataury.soloJ.global.security.SecurityUtils;
 import com.dataury.soloJ.global.security.TokenProvider;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
@@ -158,12 +158,14 @@ public class AuthService {
 
     //로그아웃
     @Transactional
-    public void logout(Long userId) {
+    public void logout() {
+        Long userId = SecurityUtils.getCurrentUserId();
         refreshTokenRepository.deleteByUserId(userId);
     }
 
     @Transactional
-    public AuthResponseDTO.SignResponseDTO setProfile(Long userId, AuthRequestDTO.KakaoRequestDTO dto) {
+    public AuthResponseDTO.SignResponseDTO setProfile(AuthRequestDTO.KakaoRequestDTO dto) {
+        Long userId = SecurityUtils.getCurrentUserId();
 
         try {
             User user = userRepository.findById(userId)

--- a/src/main/java/com/dataury/soloJ/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/dataury/soloJ/global/config/WebSecurityConfig.java
@@ -56,9 +56,9 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/index.html", "/static/**", "/favicon.ico").permitAll()
                         .requestMatchers("/swagger", "/swagger/", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 허용
-                        //.requestMatchers("/api/user/**", "/api/booths/**", "/api/**").permitAll()   // /api 이하 경로 접근 허용\
-                        .requestMatchers("/api/**").permitAll()
+                        .requestMatchers("/api/auth/**","/api/tourist-spots").permitAll()
                         .requestMatchers("/login", "/oauth2/**").permitAll()
+                        .requestMatchers("/api/**").authenticated()
                         .requestMatchers("/api/ws", "/api/ws/**", "/api/ws/info/**").permitAll()
                         .requestMatchers("/ws", "/ws/**", "/ws/info/**").permitAll()  // WebSocket 엔드포인트 허용
                         .requestMatchers("/favicon.ico").permitAll()

--- a/src/main/java/com/dataury/soloJ/global/security/SecurityUtils.java
+++ b/src/main/java/com/dataury/soloJ/global/security/SecurityUtils.java
@@ -1,0 +1,39 @@
+package com.dataury.soloJ.global.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtils {
+
+    private SecurityUtils() {}
+
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        System.out.println(">> SecurityUtils authentication = " + authentication);
+        if (authentication != null) {
+            System.out.println(">> SecurityUtils principal = " + authentication.getPrincipal());
+        }
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Long) {
+            return (Long) principal;
+        }
+
+        if (principal instanceof String) {
+            try {
+                return Long.parseLong((String) principal);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/dataury/soloJ/global/security/TokenProvider.java
+++ b/src/main/java/com/dataury/soloJ/global/security/TokenProvider.java
@@ -2,6 +2,7 @@
 package com.dataury.soloJ.global.security;
 
 
+import com.dataury.soloJ.domain.user.entity.User;
 import com.dataury.soloJ.global.code.status.ErrorStatus;
 import com.dataury.soloJ.global.exception.GeneralException;
 import io.jsonwebtoken.Claims;
@@ -9,14 +10,12 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import com.dataury.soloJ.domain.user.entity.User;
-import jakarta.annotation.PostConstruct;
 
 import javax.crypto.SecretKey;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 @Component
@@ -80,10 +79,11 @@ public class TokenProvider {
         }
     }
 
-    // 사용자명 추출
-    public String extractUsernameFromToken(String token) {
-        return extractClaims(token).getSubject(); // JWT의 subject에서 사용자명 추출
+    public String extractUserRoleFromToken(String token) {
+        return extractClaims(token).get("role", String.class);
     }
+
+
 
     // 사용자 ID 추출
     public Long extractUserIdFromToken(String token) {


### PR DESCRIPTION
## 🎋 관련 이슈

- #12 

## ⚡️ 작업동기

- 서비스 전반에 걸쳐 인증이 필요한 API 요청에 대해 일관된 보안 처리를 하기 위해 JWT 기반 인증 구조를 구현
- 로그인 시 발급한 JWT 토큰을 통해 사용자를 식별하고, SecurityContext에서 현재 사용자 정보를 조회할 수 있도록 하기 위함

## 🔑 주요 변경사항

TokenProvider
- AccessToken / RefreshToken 생성
- 토큰에서 userId, role 추출 기능
- 토큰 유효성 검증 기능

JwtAuthenticationFilter
- 모든 요청에 대해 토큰 검증
- 인증 성공 시 SecurityContext에 사용자 ID 및 권한 저장

SecurityUtils
- 현재 로그인한 사용자 ID를 어디서든 쉽게 조회할 수 있는 유틸리티 제공

WebSecurityConfig
- 인증 필요/불필요 경로 설정
- JWT 필터 시큐리티 필터 체인에 등록

## 💡 유의사항 또는 기타

- 현재는 권한(Authorization) 세분화 없이 모든 /api/** 요청은 인증만 필요
- 이후 /api/admin/** 와 /api/user/** 등 역할별 권한 제어 추가 가능
토큰 발급 시 role 정보가 반드시 포함되어야 함

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!