### PR TITLE
feat: 리뷰 API 및 영수증 인증 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ out/
 *.tar
 
 .env
+
+
+### Google Cloud Credential 파일 ###
+google-credential.json
+src/main/resources/google-credential.json

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+
+	implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
+	implementation 'com.google.cloud:google-cloud-vision:3.31.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dataury/soloJ/domain/ai/service/ChatGPTService.java
+++ b/src/main/java/com/dataury/soloJ/domain/ai/service/ChatGPTService.java
@@ -31,8 +31,6 @@ public class ChatGPTService {
             headers.setBearerAuth(apiKey);
 
             String requestBody = buildChatRequestBody(prompt);
-            System.out.println("[DEBUG] OpenAI 요청 JSON ↓↓↓↓↓");
-            System.out.println(requestBody);
 
             HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
             ResponseEntity<String> response = restTemplate.postForEntity(endpoint, request, String.class);
@@ -42,8 +40,6 @@ public class ChatGPTService {
                 JsonNode root = mapper.readTree(response.getBody());
                 String result = root.path("choices").get(0).path("message").path("content").asText();
 
-                System.out.println("[DEBUG] OpenAI 응답 ↓↓↓↓↓");
-                System.out.println(result);
 
                 return result.trim();
             } else {

--- a/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
@@ -1,0 +1,35 @@
+package com.dataury.soloJ.domain.review.controller;
+
+import com.dataury.soloJ.domain.review.dto.ReviewResponseDto;
+import com.dataury.soloJ.domain.review.service.ReviewService;
+import com.dataury.soloJ.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+@Tag(name = "Review API", description = "리뷰 API")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+
+    @GetMapping("/{contentTypeId}")
+    @Operation(summary = "리뷰 생성전 혼놀 포인트", description = "혼놀포인트를 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    private ApiResponse<List<ReviewResponseDto.ReviewTagResponseDto>> getReviewTags(@PathVariable int contentTypeId) {
+        return ApiResponse.onSuccess(reviewService.getTagsByContentTypeId(contentTypeId));
+    }
+
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -67,6 +68,15 @@ public class ReviewController {
     })
     public ApiResponse<ReviewResponseDto.ReviewDetailDto> getReview(@PathVariable Long reviewId){
         return ApiResponse.onSuccess(reviewService.getDetailReview(reviewId));
+    }
+
+    @GetMapping(value = "/{contentId}/receipt", consumes = "multipart/form-data")
+    @Operation(summary = "영수증 인증 여부 조회", description = "영수증 인증 여부를 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<Boolean> verifyReceipt (@PathVariable Long contentId, @RequestParam("file") MultipartFile file){
+        return ApiResponse.onSuccess(reviewService.verifyReceipt(contentId, file));
     }
 
 

--- a/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
@@ -39,4 +39,25 @@ public class ReviewController {
         return ApiResponse.onSuccess(reviewService.createReview(reviewCreateDto));
     }
 
+    @PatchMapping("/{reviewId}")
+    @Operation(summary = "리뷰 수정", description = "리뷰를 수정합니다. 토큰 필요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<ReviewResponseDto.ReviewDto> updateReview(
+            @PathVariable Long reviewId,
+            @RequestBody ReviewRequestDto.ReviewUpdateDto reviewUpdateDto){
+        return ApiResponse.onSuccess(reviewService.updateReview(reviewId, reviewUpdateDto));
+    }
+
+    @DeleteMapping("/{reviewId}")
+    @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다. 토큰 필요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<String> deleteReview(@PathVariable Long reviewId){
+        reviewService.deleteReview(reviewId);
+        return ApiResponse.onSuccess("리뷰가 삭제되었습니다.");
+    }
+
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.dataury.soloJ.domain.review.controller;
 
+import com.dataury.soloJ.domain.review.dto.ReviewRequestDto;
 import com.dataury.soloJ.domain.review.dto.ReviewResponseDto;
 import com.dataury.soloJ.domain.review.service.ReviewService;
 import com.dataury.soloJ.global.ApiResponse;
@@ -7,10 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -30,6 +28,15 @@ public class ReviewController {
     })
     private ApiResponse<List<ReviewResponseDto.ReviewTagResponseDto>> getReviewTags(@PathVariable int contentTypeId) {
         return ApiResponse.onSuccess(reviewService.getTagsByContentTypeId(contentTypeId));
+    }
+
+    @PostMapping("/")
+    @Operation(summary = "리뷰 생성", description = "리뷰를 생성합니다. 토큰 필요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<ReviewResponseDto.ReviewDto> createReview(@RequestBody ReviewRequestDto.ReviewCreateDto reviewCreateDto){
+        return ApiResponse.onSuccess(reviewService.createReview(reviewCreateDto));
     }
 
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
@@ -27,7 +27,7 @@ public class ReviewController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    private ApiResponse<List<ReviewResponseDto.ReviewTagResponseDto>> getReviewTags(@PathVariable int contentTypeId) {
+    public ApiResponse<List<ReviewResponseDto.ReviewTagResponseDto>> getReviewTags(@PathVariable int contentTypeId) {
         return ApiResponse.onSuccess(reviewService.getTagsByContentTypeId(contentTypeId));
     }
 
@@ -70,7 +70,7 @@ public class ReviewController {
         return ApiResponse.onSuccess(reviewService.getDetailReview(reviewId));
     }
 
-    @GetMapping(value = "/{contentId}/receipt", consumes = "multipart/form-data")
+    @PostMapping(value = "/{contentId}/receipt", consumes = "multipart/form-data")
     @Operation(summary = "영수증 인증 여부 조회", description = "영수증 인증 여부를 반환합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),

--- a/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/controller/ReviewController.java
@@ -60,4 +60,14 @@ public class ReviewController {
         return ApiResponse.onSuccess("리뷰가 삭제되었습니다.");
     }
 
+    @GetMapping("/{reviewId}/detail")
+    @Operation(summary = "리뷰 단일 상세 조회", description = "리뷰를 상세조회합니다. 토큰 필요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<ReviewResponseDto.ReviewDetailDto> getReview(@PathVariable Long reviewId){
+        return ApiResponse.onSuccess(reviewService.getDetailReview(reviewId));
+    }
+
+
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewRequestDto.java
@@ -1,0 +1,23 @@
+package com.dataury.soloJ.domain.review.dto;
+
+import com.dataury.soloJ.domain.review.entity.status.Difficulty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ReviewRequestDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ReviewCreateDto{
+        private Long contentId;
+        private String text;
+        private Difficulty difficulty;
+        private List<Integer> tagCodes;
+        private LocalDateTime visitDate;
+    }
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewRequestDto.java
@@ -4,8 +4,9 @@ import com.dataury.soloJ.domain.review.entity.status.Difficulty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public class ReviewRequestDto {
@@ -13,11 +14,24 @@ public class ReviewRequestDto {
     @Getter
     @Builder
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class ReviewCreateDto{
         private Long contentId;
         private String text;
         private Difficulty difficulty;
         private List<Integer> tagCodes;
-        private LocalDateTime visitDate;
+        private LocalDate visitDate;
+        private Boolean receipt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReviewUpdateDto{
+        private String text;
+        private Difficulty difficulty;
+        private List<Integer> tagCodes;
+        private LocalDate visitDate;
     }
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,14 @@
+package com.dataury.soloJ.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class ReviewResponseDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class ReviewTagResponseDto {
+        private int code;
+        private String description;
+    }
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewResponseDto.java
@@ -1,7 +1,12 @@
 package com.dataury.soloJ.domain.review.dto;
 
+import com.dataury.soloJ.domain.review.entity.status.Difficulty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public class ReviewResponseDto {
 
@@ -18,4 +23,26 @@ public class ReviewResponseDto {
         private Long id;
         private String content;
     }
+
+    // ReviewResponseDto.java
+    @Getter @Builder
+    public static class ReviewDetailDto {
+        private Long id;
+        private Long contentId;
+        private String content;
+        private String text;
+        private Difficulty difficulty;
+        private LocalDate visitDate; // 엔티티에 맞춰 LocalDate 또는 LocalDateTime
+        private Boolean receipt;
+        private List<TagItem> tags;          // 전체 목록 + selected
+        private List<Integer> selectedTagCodes; // (옵션) 선택 코드만
+    }
+
+    @Getter @AllArgsConstructor
+    public static class TagItem {
+        private int code;
+        private String description;
+        private boolean selected;
+    }
+
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/dto/ReviewResponseDto.java
@@ -11,4 +11,11 @@ public class ReviewResponseDto {
         private int code;
         private String description;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ReviewDto{
+        private Long id;
+        private String content;
+    }
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/entity/Review.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/entity/Review.java
@@ -5,9 +5,12 @@ import com.dataury.soloJ.domain.touristSpot.entity.TouristSpot;
 import com.dataury.soloJ.domain.user.entity.User;
 import com.dataury.soloJ.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +18,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Setter
 @Builder
 public class Review extends BaseEntity {
     @Id
@@ -24,7 +26,7 @@ public class Review extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private LocalDateTime visitDate;
+    private LocalDate visitDate;
 
     @Column
     private String reviewText;
@@ -32,6 +34,10 @@ public class Review extends BaseEntity {
     @Column
     @Enumerated(EnumType.STRING)
     private Difficulty difficulty;
+
+    @Column
+    @Builder.Default
+    private Boolean receipt=false;
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewTag> reviewTags = new ArrayList<>();
@@ -43,4 +49,28 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "touristSpot_id")
     private TouristSpot touristSpot;
+
+    // 리뷰 정보 업데이트 (부분 수정 가능)
+    public void updateReview(String reviewText, Difficulty difficulty, LocalDate visitDate) {
+        if (reviewText != null) {
+            this.reviewText = reviewText;
+        }
+        if (difficulty != null) {
+            this.difficulty = difficulty;
+        }
+        if (visitDate != null) {
+            this.visitDate = visitDate;
+        }
+    }
+
+    // 리뷰 태그 업데이트
+    public void updateReviewTags(List<ReviewTag> newReviewTags) {
+        this.reviewTags.clear();
+        this.reviewTags.addAll(newReviewTags);
+    }
+
+    // 리뷰 태그 설정 (생성 시 사용)
+    public void setReviewTags(List<ReviewTag> reviewTags) {
+        this.reviewTags = reviewTags;
+    }
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/entity/Review.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/entity/Review.java
@@ -39,6 +39,7 @@ public class Review extends BaseEntity {
     @Builder.Default
     private Boolean receipt=false;
 
+    @Builder.Default
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewTag> reviewTags = new ArrayList<>();
 
@@ -65,12 +66,15 @@ public class Review extends BaseEntity {
 
     // 리뷰 태그 업데이트
     public void updateReviewTags(List<ReviewTag> newReviewTags) {
+        if (this.reviewTags == null) this.reviewTags = new ArrayList<>();           // ✅ 방어
         this.reviewTags.clear();
-        this.reviewTags.addAll(newReviewTags);
+        if (newReviewTags == null) return;                                          // ✅ null 들어와도 안전
+        for (ReviewTag t : newReviewTags) {
+            t.setReview(this);                                                      // 역방향 보장
+            this.reviewTags.add(t);
+        }
     }
 
-    // 리뷰 태그 설정 (생성 시 사용)
-    public void setReviewTags(List<ReviewTag> reviewTags) {
-        this.reviewTags = reviewTags;
-    }
+
+
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/entity/Review.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/entity/Review.java
@@ -1,7 +1,6 @@
 package com.dataury.soloJ.domain.review.entity;
 
 import com.dataury.soloJ.domain.review.entity.status.Difficulty;
-import com.dataury.soloJ.domain.review.entity.status.ReviewTags;
 import com.dataury.soloJ.domain.touristSpot.entity.TouristSpot;
 import com.dataury.soloJ.domain.user.entity.User;
 import com.dataury.soloJ.global.common.BaseEntity;
@@ -9,6 +8,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @AllArgsConstructor
@@ -32,9 +33,8 @@ public class Review extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Difficulty difficulty;
 
-    @Column
-    @Enumerated(EnumType.STRING)
-    private ReviewTags reviewTags;
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewTag> reviewTags = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/dataury/soloJ/domain/review/entity/ReviewTag.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/entity/ReviewTag.java
@@ -1,0 +1,27 @@
+package com.dataury.soloJ.domain.review.entity;
+
+import com.dataury.soloJ.domain.review.entity.status.ReviewTags;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ReviewTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_tag_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReviewTags tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/entity/status/ReviewTags.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/entity/status/ReviewTags.java
@@ -3,33 +3,38 @@ package com.dataury.soloJ.domain.review.entity.status;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @AllArgsConstructor
 @Getter
 public enum ReviewTags {
 
-    // 관광지(14) - 100번대
-    TOUR_PHOTO(101, "혼자 사진 찍기 좋았어요", 14),
-    TOUR_RELAX(102, "한적하고 여유로웠어요", 14),
-    TOUR_GUIDE_KIND(103, "혼자여도 직원/가이드가 친절했어요", 14),
-    TOUR_EASY_PATH(104, "길 찾기 쉽고 표지판이 잘 되어 있었어요", 14),
-    TOUR_PHOTOZONE(105, "포토존이 많았어요", 14),
-    TOUR_SEAT(106, "의자가 곳곳에 있어 쉬기 좋았어요", 14),
-    TOUR_LIGHTING(107, "조명이 예뻐서 혼자 사진 찍기 좋았어요", 14),
-    TOUR_DESCRIPTION(108, "안내문/설명이 혼자 읽기 쉽게 잘 되어 있었어요", 14),
-    TOUR_ACCESS(109, "주차/대중교통 접근성이 좋아요", 14),
-    TOUR_SCALE(110, "혼자 둘러보기 적당한 규모였어요", 14),
+    // 관광지(12) - 100번대
+    TOUR_PHOTO(101, "혼자 사진 찍기 좋았어요", 12),
+    TOUR_RELAX(102, "한적하고 여유로웠어요", 12),
+    TOUR_GUIDE_KIND(103, "혼자여도 직원/가이드가 친절했어요", 12),
+    TOUR_EASY_PATH(104, "길 찾기 쉽고 표지판이 잘 되어 있었어요", 12),
+    TOUR_PHOTOZONE(105, "포토존이 많았어요", 12),
+    TOUR_SEAT(106, "의자가 곳곳에 있어 쉬기 좋았어요", 12),
+    TOUR_LIGHTING(107, "조명이 예뻐서 혼자 사진 찍기 좋았어요", 12),
+    TOUR_DESCRIPTION(108, "안내문/설명이 혼자 읽기 쉽게 잘 되어 있었어요", 12),
+    TOUR_ACCESS(109, "주차/대중교통 접근성이 좋아요", 12),
+    TOUR_SCALE(110, "혼자 둘러보기 적당한 규모였어요", 12),
 
-    // 문화시설(16) - 200번대
-    CULTURE_QUIET(201, "조용하고 집중하기 좋았어요", 16),
-    CULTURE_EASY_VIEW(202, "혼자 관람하기 부담 없었어요", 16),
-    CULTURE_KIND_STAFF(203, "직원/해설사가 친절했어요", 16),
-    CULTURE_TIME(204, "전시/체험 시간이 적당했어요", 16),
-    CULTURE_LONG_STAY(205, "혼자 오래 머물러도 좋았어요", 16),
-    CULTURE_SIMPLE_ROUTE(206, "내부 동선이 간단해서 혼자 다니기 편했어요", 16),
-    CULTURE_EASY_RESERVE(207, "예약/티켓팅이 간단했어요", 16),
-    CULTURE_CLEAN_FACILITY(208, "화장실/편의시설이 깨끗하고 가까웠어요", 16),
-    CULTURE_EASY_INFO(209, "설명/자료가 혼자 이해하기 좋았어요", 16),
-    CULTURE_NOT_NOISY(210, "관람객이 많아도 시끄럽지 않았어요", 16),
+    // 문화시설(14) - 200번대
+    CULTURE_QUIET(201, "조용하고 집중하기 좋았어요", 14),
+    CULTURE_EASY_VIEW(202, "혼자 관람하기 부담 없었어요", 14),
+    CULTURE_KIND_STAFF(203, "직원/해설사가 친절했어요", 14),
+    CULTURE_TIME(204, "전시/체험 시간이 적당했어요", 14),
+    CULTURE_LONG_STAY(205, "혼자 오래 머물러도 좋았어요", 14),
+    CULTURE_SIMPLE_ROUTE(206, "내부 동선이 간단해서 혼자 다니기 편했어요", 14),
+    CULTURE_EASY_RESERVE(207, "예약/티켓팅이 간단했어요", 14),
+    CULTURE_CLEAN_FACILITY(208, "화장실/편의시설이 깨끗하고 가까웠어요", 14),
+    CULTURE_EASY_INFO(209, "설명/자료가 혼자 이해하기 좋았어요", 14),
+    CULTURE_NOT_NOISY(210, "관람객이 많아도 시끄럽지 않았어요", 14),
 
     // 행사/공연/축제(15) - 300번대
     EVENT_COMFY_SEAT(301, "혼자 관람석에서 편안했어요", 15),
@@ -107,12 +112,22 @@ public enum ReviewTags {
     private final String description;
     private final int contentTypeId;
 
+
+    private static final Map<Integer, List<ReviewTags>> BY_CONTENT =
+            Arrays.stream(values())
+                    .collect(Collectors.groupingBy(ReviewTags::getContentTypeId, Collectors.toUnmodifiableList()));
+
+    private static final Map<Integer, ReviewTags> BY_CODE =
+            Arrays.stream(values())
+                    .collect(Collectors.toUnmodifiableMap(ReviewTags::getCode, e -> e));
+
+    public static List<ReviewTags> byContentType(int contentTypeId) {
+        return BY_CONTENT.getOrDefault(contentTypeId, List.of());
+    }
+
     public static ReviewTags fromCode(int code) {
-        for (ReviewTags tag : values()) {
-            if (tag.code == code) {
-                return tag;
-            }
-        }
-        throw new IllegalArgumentException("Invalid ReviewTag code: " + code);
+        ReviewTags tag = BY_CODE.get(code);
+        if (tag == null) throw new IllegalArgumentException("Invalid ReviewTag code: " + code);
+        return tag;
     }
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.dataury.soloJ.domain.review.repository;
+
+import com.dataury.soloJ.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review,Long> {
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review,Long> {
     @Query("SELECT r.difficulty " +
@@ -15,5 +16,16 @@ public interface ReviewRepository extends JpaRepository<Review,Long> {
             "GROUP BY r.difficulty " +
             "ORDER BY COUNT(r) DESC")
     List<Difficulty> findDifficultiesByPopularity(@Param("spotId") Long spotId);
+
+    // ReviewRepository
+    @Query("""
+        select distinct r
+        from Review r
+        join fetch r.touristSpot s
+        left join fetch r.reviewTags t
+        where r.id = :reviewId and r.user.id = :userId
+    """)
+    Optional<Review> findDetailByIdAndUser(@Param("reviewId") Long reviewId,
+                                           @Param("userId") Long userId);
 
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,19 @@
 package com.dataury.soloJ.domain.review.repository;
 
 import com.dataury.soloJ.domain.review.entity.Review;
+import com.dataury.soloJ.domain.review.entity.status.Difficulty;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review,Long> {
+    @Query("SELECT r.difficulty " +
+            "FROM Review r " +
+            "WHERE r.touristSpot.contentId = :spotId AND r.difficulty <> com.dataury.soloJ.domain.review.entity.status.Difficulty.NONE " +
+            "GROUP BY r.difficulty " +
+            "ORDER BY COUNT(r) DESC")
+    List<Difficulty> findDifficultiesByPopularity(@Param("spotId") Long spotId);
+
 }

--- a/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewTagRepository.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/repository/ReviewTagRepository.java
@@ -1,0 +1,20 @@
+package com.dataury.soloJ.domain.review.repository;
+
+import com.dataury.soloJ.domain.review.entity.ReviewTag;
+import com.dataury.soloJ.domain.review.entity.status.ReviewTags;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ReviewTagRepository extends JpaRepository<ReviewTag, Long> {
+    @Query("SELECT rt.tag " +
+            "FROM ReviewTag rt " +
+            "WHERE rt.review.touristSpot.contentId = :spotId AND rt.tag is not null " +
+            "GROUP BY rt.tag " +
+            "ORDER BY COUNT(rt) DESC")
+    List<ReviewTags> findTagsByPopularity(@Param("spotId") Long spotId);
+
+
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/service/GoogleOcrService.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/service/GoogleOcrService.java
@@ -1,0 +1,196 @@
+package com.dataury.soloJ.domain.review.service;
+
+import com.dataury.soloJ.domain.touristSpot.entity.TouristSpot;
+import com.dataury.soloJ.domain.touristSpot.repository.TouristSpotRepository;
+import com.dataury.soloJ.global.code.status.ErrorStatus;
+import com.dataury.soloJ.global.exception.GeneralException;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.vision.v1.*;
+import com.google.protobuf.ByteString;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.Normalizer;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleOcrService {
+
+    @Value("${google.application.credentials}") // 예: keys/vision-credentials.json
+    private String credentialsPath;
+
+    private final TouristSpotRepository touristSpotRepository;
+
+    /**
+     * 영수증 이미지에서 텍스트를 추출하고, contentId의 관광지 이름이 포함/유사한지 판정
+     */
+    public Boolean verifyReceipt(Long contentId, MultipartFile file) {
+        try {
+            List<String> lines = extractTextFromImage(file); // 줄 단위 텍스트
+            TouristSpot touristSpot = touristSpotRepository.findById(contentId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.TOURIST_SPOT_NOT_FOUND));
+
+            return checkReceipt(touristSpot.getName(), lines);
+
+        } catch (GeneralException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("verifyReceipt failed", e);
+            throw new GeneralException(ErrorStatus.IMAGE_TEXT_FAILD);
+        }
+    }
+
+    /**
+     * 영수증 텍스트 라인들 중 가게명이 포함/유사하면 true
+     */
+    public Boolean checkReceipt(String touristSpotName, List<String> extractedLines) {
+        if (touristSpotName == null || touristSpotName.isBlank()) return false;
+        if (extractedLines == null || extractedLines.isEmpty()) return false;
+
+        String normTarget = normalizeName(touristSpotName);
+        Set<String> targetVariants = buildNameVariants(normTarget);
+
+        // 전체 텍스트(합본)에도 한 번에 검사
+        String merged = extractedLines.stream()
+                .map(this::normalizeName)
+                .collect(Collectors.joining("\n"));
+
+        if (matchesAnyVariant(merged, targetVariants)) return true;
+
+        // 라인 단위 검사(+ 간단 유사도)
+        for (String line : extractedLines) {
+            String normLine = normalizeName(line);
+
+            if (matchesAnyVariant(normLine, targetVariants)) return true;
+
+            // 짧은 상호명의 오인식을 대비해 간단한 레벤슈타인 유사도 체크(0.85 이상)
+            double sim = similarity(normLine, normTarget);
+            if (sim >= 0.85) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Vision API로 문서 전체 텍스트(DOCUMENT_TEXT_DETECTION) 추출 후 줄 단위로 반환
+     */
+    public List<String> extractTextFromImage(MultipartFile file) throws IOException {
+        try (InputStream credentialsStream = new ClassPathResource(credentialsPath).getInputStream()) {
+            GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsStream);
+            ImageAnnotatorSettings settings = ImageAnnotatorSettings.newBuilder()
+                    .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
+                    .build();
+
+            try (ImageAnnotatorClient vision = ImageAnnotatorClient.create(settings)) {
+                ByteString imgBytes = ByteString.copyFrom(file.getBytes());
+                Image img = Image.newBuilder().setContent(imgBytes).build();
+
+                Feature feat = Feature.newBuilder()
+                        .setType(Feature.Type.DOCUMENT_TEXT_DETECTION) // 영수증/문서에 더 적합
+                        .build();
+
+                // 한국어/영어 힌트
+                ImageContext context = ImageContext.newBuilder()
+                        .addLanguageHints("ko")
+                        .addLanguageHints("en")
+                        .build();
+
+                AnnotateImageRequest request = AnnotateImageRequest.newBuilder()
+                        .addFeatures(feat)
+                        .setImage(img)
+                        .setImageContext(context)
+                        .build();
+
+                BatchAnnotateImagesResponse response = vision.batchAnnotateImages(List.of(request));
+                AnnotateImageResponse res = response.getResponsesList().get(0);
+
+                if (res.hasError()) {
+                    log.warn("Vision API error: {}", res.getError().getMessage());
+                    throw new GeneralException(ErrorStatus.IMAGE_TEXT_FAILD);
+                }
+
+                String full = res.getFullTextAnnotation() != null
+                        ? res.getFullTextAnnotation().getText()
+                        : res.getTextAnnotationsList().isEmpty()
+                        ? ""
+                        : res.getTextAnnotationsList().get(0).getDescription();
+
+                // 줄 단위 파싱 + 중복 제거
+                return Arrays.stream(full.split("\\r?\\n"))
+                        .map(String::trim)
+                        .filter(s -> !s.isBlank())
+                        .distinct()
+                        .limit(500) // 방어적 제한
+                        .collect(Collectors.toList());
+            }
+        }
+    }
+
+    /* ===================== 문자열 유틸 ===================== */
+
+    // 한글/영문/숫자만 남기고 공백·기호 제거 + 소문자 + 정규화(NFKD) + 흔한 접두/접미어 제거
+    private String normalizeName(String s) {
+        String n = Normalizer.normalize(s, Normalizer.Form.NFKD)
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", "")                // 모든 공백 제거
+                .replaceAll("[^0-9a-z가-힣]", "");     // 영문/숫자/한글 외 제거
+
+        // 사업자/지점 표기 제거 (예: ㈜, (주), 주식회사, 본점, 지점, ○○점 등)
+        n = n.replace("주식회사", "")
+                .replace("㈜", "")
+                .replace("(주)", "")
+                .replace("본점", "")
+                .replace("지점", "")
+                .replace("점", ""); // ‘스타벅스무슨무슨점’ → ‘스타벅스무슨무슨’
+        return n;
+    }
+
+    private Set<String> buildNameVariants(String normTarget) {
+        Set<String> set = new HashSet<>();
+        set.add(normTarget);
+
+        // 단어(공백 기준) 조립 전제였으므로, 원래 이름에서 공백 제거 버전은 이미 normTarget.
+        // 필요 시 추가 변형(예: 괄호 안 제거 등)을 여기서 확장 가능
+        return set;
+    }
+
+    private boolean matchesAnyVariant(String haystack, Set<String> variants) {
+        for (String v : variants) {
+            if (haystack.contains(v)) return true;
+        }
+        return false;
+    }
+
+    // 간단한 레벤슈타인 기반 유사도 (1 - dist/maxLen)
+    private double similarity(String a, String b) {
+        if (a.isEmpty() || b.isEmpty()) return 0.0;
+        int dist = levenshtein(a, b);
+        int max = Math.max(a.length(), b.length());
+        return 1.0 - (double) dist / max;
+    }
+
+    private int levenshtein(String s1, String s2) {
+        int[][] dp = new int[s1.length() + 1][s2.length() + 1];
+        for (int i = 0; i <= s1.length(); i++) dp[i][0] = i;
+        for (int j = 0; j <= s2.length(); j++) dp[0][j] = j;
+        for (int i = 1; i <= s1.length(); i++) {
+            for (int j = 1; j <= s2.length(); j++) {
+                int cost = (s1.charAt(i - 1) == s2.charAt(j - 1)) ? 0 : 1;
+                dp[i][j] = Math.min(
+                        Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1),
+                        dp[i - 1][j - 1] + cost
+                );
+            }
+        }
+        return dp[s1.length()][s2.length()];
+    }
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
@@ -1,0 +1,24 @@
+package com.dataury.soloJ.domain.review.service;
+
+import com.dataury.soloJ.domain.review.dto.ReviewResponseDto;
+import com.dataury.soloJ.domain.review.entity.status.ReviewTags;
+import com.dataury.soloJ.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+
+    public List<ReviewResponseDto.ReviewTagResponseDto> getTagsByContentTypeId(int contentTypeId) {
+        return Arrays.stream(ReviewTags.values())
+                .filter(tag -> tag.getContentTypeId() == contentTypeId)
+                .map(tag -> new ReviewResponseDto.ReviewTagResponseDto(tag.getCode(), tag.getDescription()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
@@ -83,8 +83,6 @@ public class ReviewService {
         ReviewTags mainTag = reviewTagRepository.findTagsByPopularity(touristSpot.getContentId())
                 .stream().findFirst().orElse(null);
 
-        System.out.println(mainDiff);
-        System.out.println(mainTag);
 
         touristSpot.updateMainStats(mainDiff, mainTag);
         touristSpotRepository.save(touristSpot);

--- a/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
@@ -18,6 +18,7 @@ import com.dataury.soloJ.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ public class ReviewService {
     private final UserRepository userRepository;
     private final TouristSpotRepository touristSpotRepository;
     private final ReviewTagRepository reviewTagRepository;
+    private final GoogleOcrService googleOcrService;
 
     // contentTypeId로 리뷰 태그 목록 조회
     public List<ReviewResponseDto.ReviewTagResponseDto> getTagsByContentTypeId(int contentTypeId) {
@@ -211,6 +213,10 @@ public class ReviewService {
                 .build();
     }
 
+    public Boolean verifyReceipt(Long contentId, MultipartFile file) {
+        return googleOcrService.verifyReceipt(contentId, file);
+
+    }
 
 
 

--- a/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/dataury/soloJ/domain/review/service/ReviewService.java
@@ -1,10 +1,23 @@
 package com.dataury.soloJ.domain.review.service;
 
+import com.dataury.soloJ.domain.review.dto.ReviewRequestDto;
 import com.dataury.soloJ.domain.review.dto.ReviewResponseDto;
+import com.dataury.soloJ.domain.review.entity.Review;
+import com.dataury.soloJ.domain.review.entity.ReviewTag;
+import com.dataury.soloJ.domain.review.entity.status.Difficulty;
 import com.dataury.soloJ.domain.review.entity.status.ReviewTags;
 import com.dataury.soloJ.domain.review.repository.ReviewRepository;
+import com.dataury.soloJ.domain.review.repository.ReviewTagRepository;
+import com.dataury.soloJ.domain.touristSpot.entity.TouristSpot;
+import com.dataury.soloJ.domain.touristSpot.repository.TouristSpotRepository;
+import com.dataury.soloJ.domain.user.entity.User;
+import com.dataury.soloJ.domain.user.repository.UserRepository;
+import com.dataury.soloJ.global.code.status.ErrorStatus;
+import com.dataury.soloJ.global.exception.GeneralException;
+import com.dataury.soloJ.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
@@ -14,11 +27,70 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ReviewService {
     private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final TouristSpotRepository touristSpotRepository;
+    private final ReviewTagRepository reviewTagRepository;
 
+    // contentTypeId로 리뷰 태그 목록 조회
     public List<ReviewResponseDto.ReviewTagResponseDto> getTagsByContentTypeId(int contentTypeId) {
         return Arrays.stream(ReviewTags.values())
                 .filter(tag -> tag.getContentTypeId() == contentTypeId)
                 .map(tag -> new ReviewResponseDto.ReviewTagResponseDto(tag.getCode(), tag.getDescription()))
                 .collect(Collectors.toList());
     }
+
+    // 리뷰 생성
+    @Transactional
+    public ReviewResponseDto.ReviewDto createReview(ReviewRequestDto.ReviewCreateDto reviewCreateDto) {
+        // 로그인한 사용자 찾기
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 관광지 찾기
+        TouristSpot touristSpot = touristSpotRepository.findById(reviewCreateDto.getContentId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.TOURIST_SPOT_NOT_FOUND));
+
+        // 리뷰 생성
+        Review review = Review.builder()
+                .user(user)
+                .touristSpot(touristSpot)
+                .reviewText(reviewCreateDto.getText())
+                .difficulty(reviewCreateDto.getDifficulty())
+                .visitDate(reviewCreateDto.getVisitDate())
+                .build();
+
+        // 태그 저장 (최대 3개)
+        List<ReviewTag> reviewTagList = reviewCreateDto.getTagCodes().stream()
+                .limit(3)
+                .map(code -> ReviewTag.builder()
+                        .review(review)
+                        .tag(ReviewTags.fromCode(code))
+                        .build())
+                .toList();
+
+        review.setReviewTags(reviewTagList);
+
+        Review savedReview = reviewRepository.save(review);
+
+        // ✅ 대표 난이도 / 태그 갱신 (동점 있으면 첫 번째 값만 사용)
+        Difficulty mainDiff = reviewRepository.findDifficultiesByPopularity(touristSpot.getContentId())
+                .stream().findFirst().orElse(Difficulty.NONE);
+
+        ReviewTags mainTag = reviewTagRepository.findTagsByPopularity(touristSpot.getContentId())
+                .stream().findFirst().orElse(null);
+
+        System.out.println(mainDiff);
+        System.out.println(mainTag);
+
+        touristSpot.updateMainStats(mainDiff, mainTag);
+        touristSpotRepository.save(touristSpot);
+
+        return new ReviewResponseDto.ReviewDto(
+                savedReview.getId(),
+                savedReview.getReviewText()
+        );
+    }
+
+
 }

--- a/src/main/java/com/dataury/soloJ/domain/touristSpot/dto/TourSpotResponse.java
+++ b/src/main/java/com/dataury/soloJ/domain/touristSpot/dto/TourSpotResponse.java
@@ -31,9 +31,10 @@ public class TourSpotResponse {
         private String firstimage;
         private String mapx;
         private String mapy;
+        private boolean hasCompanionRoom;
 
         private Difficulty difficulty;
-        private List<String> reviewTags;
+        private String reviewTags;
     }
 
 
@@ -57,7 +58,7 @@ public class TourSpotResponse {
         private Map<String, Object> intro;
         private List<String> reviewTags;
         private Difficulty difficulty;
-        private int activeGroupCount;
+        private boolean hasCompanionRoom;
     }
 
 

--- a/src/main/java/com/dataury/soloJ/domain/touristSpot/entity/TouristSpot.java
+++ b/src/main/java/com/dataury/soloJ/domain/touristSpot/entity/TouristSpot.java
@@ -22,7 +22,7 @@ public class TouristSpot extends BaseEntity {
     private String name;
 
     @Column(nullable = false)
-    private Long contentTypeId;
+    private int contentTypeId;
 
     @Column(nullable = false)
     private double latitude;

--- a/src/main/java/com/dataury/soloJ/domain/touristSpot/entity/TouristSpot.java
+++ b/src/main/java/com/dataury/soloJ/domain/touristSpot/entity/TouristSpot.java
@@ -1,7 +1,7 @@
 package com.dataury.soloJ.domain.touristSpot.entity;
 
 import com.dataury.soloJ.domain.review.entity.status.Difficulty;
-import com.dataury.soloJ.domain.touristSpot.dto.TourApiResponse;
+import com.dataury.soloJ.domain.review.entity.status.ReviewTags;
 import com.dataury.soloJ.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -38,28 +38,18 @@ public class TouristSpot extends BaseEntity {
     @Builder.Default
     private Difficulty difficulty = Difficulty.NONE;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private ReviewTags reviewTag;
+
     @Column(nullable = false)
     @Builder.Default
-    private int activeGroupCount=0;
+    private boolean hasCompanionRoom = false;
 
-    // 동행방 생성 시
-    public void incrementGroupCount() {
-        this.activeGroupCount++;
-    }
 
-    // 동행방 종료 시
-    public void decrementGroupCount() {
-        if (this.activeGroupCount > 0) {
-            this.activeGroupCount--;
-        }
-    }
-
-    public void updateFromItem(TourApiResponse.Item item) {
-        this.name = item.getTitle();
-        this.contentTypeId = Long.valueOf(item.getContenttypeid());
-        this.latitude = Double.parseDouble(item.getMapy());
-        this.longitude = Double.parseDouble(item.getMapx());
-        this.firstImage = item.getFirstimage(); // 있다면
+    public void updateMainStats(Difficulty difficulty, ReviewTags tag) {
+        this.difficulty = difficulty != null ? difficulty : Difficulty.NONE;
+        this.reviewTag = tag;
     }
 
 }

--- a/src/main/java/com/dataury/soloJ/domain/touristSpot/service/TourSpotService.java
+++ b/src/main/java/com/dataury/soloJ/domain/touristSpot/service/TourSpotService.java
@@ -61,7 +61,7 @@ public class TourSpotService {
                 spot = touristSpotRepository.save(TouristSpot.builder()
                         .contentId(contentId)
                         .name(item.getTitle())
-                        .contentTypeId(Long.valueOf(item.getContenttypeid()))
+                        .contentTypeId(Integer.parseInt(item.getContenttypeid()))
                         .latitude(Double.parseDouble(item.getMapy()))
                         .longitude(Double.parseDouble(item.getMapx()))
                         .firstImage(item.getFirstimage())

--- a/src/main/java/com/dataury/soloJ/domain/touristSpot/service/TourSpotService.java
+++ b/src/main/java/com/dataury/soloJ/domain/touristSpot/service/TourSpotService.java
@@ -65,11 +65,10 @@ public class TourSpotService {
                         .latitude(Double.parseDouble(item.getMapy()))
                         .longitude(Double.parseDouble(item.getMapx()))
                         .firstImage(item.getFirstimage())
-                        .activeGroupCount(0)
+                        .hasCompanionRoom(false)
                         .build());
             }
 
-            List<String> tagDescriptions = tagMap.getOrDefault(contentId, List.of());
 
             return TourSpotResponse.TourSpotItemWithReview.builder()
                     .contentid(item.getContentid())
@@ -80,7 +79,8 @@ public class TourSpotService {
                     .mapx(item.getMapx())
                     .mapy(item.getMapy())
                     .difficulty(spot.getDifficulty())
-                    .reviewTags(tagDescriptions)
+                    .reviewTags(spot.getReviewTag() != null ? spot.getReviewTag().getDescription() : null)
+                    .hasCompanionRoom(spot.isHasCompanionRoom())
                     .build();
         }).toList();
 
@@ -129,7 +129,7 @@ public class TourSpotService {
                 .intro(intro)
                 .reviewTags(reviewTags)
                 .difficulty(spot.getDifficulty())
-                .activeGroupCount(spot.getActiveGroupCount())
+                .hasCompanionRoom(spot.isHasCompanionRoom())
                 .build();
     }
 

--- a/src/main/java/com/dataury/soloJ/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/dataury/soloJ/global/code/status/ErrorStatus.java
@@ -61,7 +61,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     IMAGE_FAILED(HttpStatus.BAD_REQUEST,"IMAGE4001","이미지 올리는 것을 실패하였습니다."),
 
-    IMAGE_TEXT_FAILD(HttpStatus.BAD_REQUEST, "IMAGETEXT4001", "이미지 텍스트 추출을 실패하였습니다.");
+    IMAGE_TEXT_FAILD(HttpStatus.BAD_REQUEST, "IMAGETEXT4001", "이미지 텍스트 추출을 실패하였습니다."),
+
+    // Review 관련 에러
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW4001", "존재하지 않는 리뷰입니다."),
+    REVIEW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "REVIEW4002", "해당 리뷰에 대한 권한이 없습니다.");
 
 
 

--- a/src/main/java/com/dataury/soloJ/global/security/SecurityUtils.java
+++ b/src/main/java/com/dataury/soloJ/global/security/SecurityUtils.java
@@ -36,17 +36,13 @@ public class SecurityUtils {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         
         if (authentication == null || authentication.getAuthorities() == null) {
-            System.out.println(">> SecurityUtils.isAdmin: No authentication or authorities");
             return false;
         }
-        
-        System.out.println(">> SecurityUtils.isAdmin: Authorities = " + authentication.getAuthorities());
         
         boolean isAdmin = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .anyMatch(authority -> authority.equals("ROLE_ADMIN"));
-        
-        System.out.println(">> SecurityUtils.isAdmin: Result = " + isAdmin);
+
         return isAdmin;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,3 +85,6 @@ management:
       exposure:
         include: health,info
 
+google:
+  application:
+    credentials: "google-credential.json"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update # 스키마 자동 업데이트
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 🎋 관련 이슈

- #20

## ⚡️ 작업동기

- 관광지 리뷰 CRUD 및 혼놀 포인트(태그) 기능 구현 필요

영수증 OCR 기반 인증 기능 추가 요구사항 대응

## 🔑 주요 변경사항

- ReviewController/ReviewService 추가
- 리뷰 생성, 수정, 삭제, 단일 조회 API 구현
- contentTypeId 기반 리뷰 태그 조회 API 구현
- 영수증 인증 여부 확인 API 구현 (Google Vision OCR 연동)
- Review 엔티티 리팩토링
- visitDate 타입 LocalDate로 변경
- ReviewTag 엔티티 분리 (N:1 관계 매핑)
- Google Cloud Vision API 연동 서비스 (GoogleOcrService)
- .gitignore에 google-credential.json 명시

## 💡 유의사항 또는 기타

- GCP Service Account 키는 .gitignore에 추가되어 있음 (코드에 포함되지 않음)
- application.yml에 google.application.credentials 경로 설정 필요
- OCR 인증 로직은 단순 문자열 포함 + 유사도 기반으로 동작하므로 실제 테스트 필요

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!