### PR TITLE
feat#25: 메시지 읽음처리 및 채팅방 성별 관련 로직 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ out/
 ### Google Cloud Credential 파일 ###
 google-credential.json
 src/main/resources/google-credential.json
+
+app.jar

--- a/src/main/java/com/dataury/soloJ/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/controller/ChatRoomController.java
@@ -3,7 +3,6 @@ package com.dataury.soloJ.domain.chat.controller;
 import com.dataury.soloJ.domain.chat.dto.ChatMessageDto;
 import com.dataury.soloJ.domain.chat.dto.ChatRoomRequestDto;
 import com.dataury.soloJ.domain.chat.dto.ChatRoomResponseDto;
-import com.dataury.soloJ.domain.chat.entity.Message;
 import com.dataury.soloJ.domain.chat.service.ChatRoomCommandService;
 import com.dataury.soloJ.domain.chat.service.MessageQueryService;
 import com.dataury.soloJ.global.ApiResponse;
@@ -26,7 +25,6 @@ import java.util.stream.Collectors;
 @Tag(name = "ChatAPI",description = "채팅 관련 기능 API 입니다.")
 @Slf4j
 public class ChatRoomController {
-
 
     private final ChatRoomCommandService chatRoomCommandService;
 
@@ -94,6 +92,13 @@ public class ChatRoomController {
                 roomId, userId, responses.size(), pageResponse.isHasNext());
 
         return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "채팅방 메시지 읽음 처리", description = "채팅방 입장시 모든 메시지를 읽음 처리합니다.")
+    @PostMapping("/{roomId}/read")
+    public ApiResponse<String> markMessagesAsRead(@PathVariable Long roomId) {
+        chatRoomCommandService.markAllMessagesAsRead(roomId);
+        return ApiResponse.onSuccess("모든 메시지가 읽음 처리되었습니다.");
     }
 
 }

--- a/src/main/java/com/dataury/soloJ/domain/chat/dto/ChatRoomListItem.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/dto/ChatRoomListItem.java
@@ -1,5 +1,6 @@
 package com.dataury.soloJ.domain.chat.dto;
 
+import com.dataury.soloJ.domain.user.entity.status.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,4 +20,6 @@ public class ChatRoomListItem {
     private final Long currentMembers;  // count() → Long
     private final Long maxMembers;   // 정원
     private final Boolean isCompleted;
+    private final Boolean hasUnreadMessages; // 읽지 않은 메시지 여부
+    private final Gender genderRestriction; // 채팅방 성별 제한
 }

--- a/src/main/java/com/dataury/soloJ/domain/chat/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/dto/ChatRoomRequestDto.java
@@ -1,5 +1,6 @@
 package com.dataury.soloJ.domain.chat.dto;
 
+import com.dataury.soloJ.domain.user.entity.status.Gender;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,6 +17,7 @@ public class ChatRoomRequestDto {
         private Long contentId; // TouristSpot의 contentId
         private LocalDateTime joinDate;
         private Long maxMembers; // 최대 인원수
+        private Gender genderRestriction; // 성별 제한 (MALE, FEMALE, MIXED)
     }
 
     @Data

--- a/src/main/java/com/dataury/soloJ/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/dto/ChatRoomResponseDto.java
@@ -1,5 +1,6 @@
 package com.dataury.soloJ.domain.chat.dto;
 
+import com.dataury.soloJ.domain.user.entity.status.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,6 +29,7 @@ public class ChatRoomResponseDto {
         private LocalDateTime joinDate;
         private Long maxMembers;
         private int currentMembers;
+        private Gender genderRestriction;
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/dataury/soloJ/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/entity/ChatRoom.java
@@ -2,6 +2,7 @@ package com.dataury.soloJ.domain.chat.entity;
 
 
 import com.dataury.soloJ.domain.touristSpot.entity.TouristSpot;
+import com.dataury.soloJ.domain.user.entity.status.Gender;
 import com.dataury.soloJ.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -39,5 +40,9 @@ public class ChatRoom extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tourist_spot_id")
     private TouristSpot touristSpot;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender_restriction")
+    private Gender genderRestriction;
 
 }

--- a/src/main/java/com/dataury/soloJ/domain/chat/entity/MessageRead.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/entity/MessageRead.java
@@ -1,0 +1,38 @@
+package com.dataury.soloJ.domain.chat.entity;
+
+import com.dataury.soloJ.domain.user.entity.User;
+import com.dataury.soloJ.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "message_read", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "chat_room_id"}))
+public class MessageRead extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_read_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Column(name = "last_read_at")
+    private LocalDateTime lastReadAt;
+
+    public void updateLastReadAt() {
+        this.lastReadAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dataury/soloJ/domain/chat/repository/JoinChatRepository.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/repository/JoinChatRepository.java
@@ -47,7 +47,9 @@ public interface JoinChatRepository extends JpaRepository<JoinChat, Long> {
         r.joinDate,
         count(jcActive),
         r.numberOfMembers,  
-        r.isCompleted
+        r.isCompleted,
+        false,
+        r.genderRestriction
     )
     from JoinChat jcUser
         join jcUser.chatRoom r
@@ -56,7 +58,7 @@ public interface JoinChatRepository extends JpaRepository<JoinChat, Long> {
               and jcActive.status = :active
     where jcUser.user.id = :userId
       and jcUser.status = :active
-    group by r.id, r.chatRoomName, r.chatRoomDescription, r.joinDate, r.numberOfMembers, r.isCompleted
+    group by r.id, r.chatRoomName, r.chatRoomDescription, r.joinDate, r.numberOfMembers, r.isCompleted, r.genderRestriction
     order by r.createdAt desc
     """)
     List<ChatRoomListItem> findMyChatRoomsAsDto(
@@ -72,7 +74,9 @@ public interface JoinChatRepository extends JpaRepository<JoinChat, Long> {
         r.joinDate,
         count(jcActive),
         r.numberOfMembers,  
-        r.isCompleted
+        r.isCompleted,
+        false,
+        r.genderRestriction
     )
     from JoinChat jcUser
       join jcUser.chatRoom r
@@ -81,7 +85,7 @@ public interface JoinChatRepository extends JpaRepository<JoinChat, Long> {
             and jcActive.status = :active
     where jcUser.user.id = :userId
       and jcUser.status = :active
-    group by r.id, r.chatRoomName, r.chatRoomDescription, r.joinDate, r.numberOfMembers, r.isCompleted
+    group by r.id, r.chatRoomName, r.chatRoomDescription, r.joinDate, r.numberOfMembers, r.isCompleted, r.genderRestriction
     order by MAX(jcUser.createdAt) desc
     """,
                 countQuery = """
@@ -107,15 +111,17 @@ public interface JoinChatRepository extends JpaRepository<JoinChat, Long> {
         r.joinDate,
         count(jcActive),
         r.numberOfMembers,  
-        r.isCompleted
+        r.isCompleted,
+        false,
+        r.genderRestriction
     )
     from ChatRoom r
         left join JoinChat jcActive
                on jcActive.chatRoom = r
               and jcActive.status = :active
-    where r.touristSpot.id = :contentId
+    where r.touristSpot.contentId = :contentId
       and r.isCompleted = false
-    group by r.id, r.chatRoomName, r.chatRoomDescription, r.joinDate, r.numberOfMembers, r.isCompleted
+    group by r.id, r.chatRoomName, r.chatRoomDescription, r.joinDate, r.numberOfMembers, r.isCompleted, r.genderRestriction
     order by r.createdAt desc
     """)
     List<ChatRoomListItem> findRoomsByTouristSpotAsDto(@Param("contentId") Long contentId,

--- a/src/main/java/com/dataury/soloJ/domain/chat/repository/MessageReadRepository.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/repository/MessageReadRepository.java
@@ -1,0 +1,22 @@
+package com.dataury.soloJ.domain.chat.repository;
+
+import com.dataury.soloJ.domain.chat.entity.ChatRoom;
+import com.dataury.soloJ.domain.chat.entity.MessageRead;
+import com.dataury.soloJ.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MessageReadRepository extends JpaRepository<MessageRead, Long> {
+    
+    Optional<MessageRead> findByUserAndChatRoom(User user, ChatRoom chatRoom);
+    
+    @Query("SELECT mr FROM MessageRead mr WHERE mr.user.id = :userId")
+    List<MessageRead> findByUserId(@Param("userId") Long userId);
+    
+    @Query("SELECT mr FROM MessageRead mr WHERE mr.chatRoom.id IN :chatRoomIds AND mr.user.id = :userId")
+    List<MessageRead> findByChatRoomIdsAndUserId(@Param("chatRoomIds") List<Long> chatRoomIds, @Param("userId") Long userId);
+}

--- a/src/main/java/com/dataury/soloJ/domain/chat/repository/mongo/MongoMessageRepository.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/repository/mongo/MongoMessageRepository.java
@@ -21,4 +21,8 @@ public interface MongoMessageRepository extends MongoRepository<Message, String>
     // 시간 범위로 메시지 조회
     List<Message> findByChatRoomIdAndCreatedAtBefore(String chatRoomId, Date createdAtBefore, Pageable pageable);
     List<Message> findByRoomIdAndSendAtBefore(Long roomId, LocalDateTime before, Pageable pageable);
+    
+    // 읽지 않은 메시지 확인용
+    boolean existsByRoomId(Long roomId);
+    boolean existsByRoomIdAndSendAtAfter(Long roomId, LocalDateTime after);
 }

--- a/src/main/java/com/dataury/soloJ/domain/chat/service/ChatRoomQueryService.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/service/ChatRoomQueryService.java
@@ -41,6 +41,8 @@ public class ChatRoomQueryService {
                         .currentMembers(r.getCurrentMembers())
                         .maxMembers(r.getMaxMembers())
                         .isCompleted(r.getIsCompleted())
+                        .hasUnreadMessages(r.getHasUnreadMessages())
+                        .genderRestriction(r.getGenderRestriction())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/dataury/soloJ/domain/chat/service/MessageReadQueryService.java
+++ b/src/main/java/com/dataury/soloJ/domain/chat/service/MessageReadQueryService.java
@@ -1,0 +1,102 @@
+package com.dataury.soloJ.domain.chat.service;
+
+import com.dataury.soloJ.domain.chat.entity.ChatRoom;
+import com.dataury.soloJ.domain.chat.entity.MessageRead;
+import com.dataury.soloJ.domain.chat.repository.MessageReadRepository;
+import com.dataury.soloJ.domain.chat.repository.mongo.MongoMessageRepository;
+import com.dataury.soloJ.domain.user.entity.User;
+import com.dataury.soloJ.domain.user.repository.UserRepository;
+import com.dataury.soloJ.global.code.status.ErrorStatus;
+import com.dataury.soloJ.global.exception.GeneralException;
+import com.dataury.soloJ.global.security.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MessageReadQueryService {
+
+    private final MessageReadRepository messageReadRepository;
+    private final MongoMessageRepository mongoMessageRepository;
+    private final UserRepository userRepository;
+
+    // 특정 채팅방에서 읽지 않은 메시지가 있는지 확인
+    public boolean hasUnreadMessages(Long chatRoomId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        MessageRead messageRead = messageReadRepository.findByUserAndChatRoom(user, 
+                ChatRoom.builder().id(chatRoomId).build()).orElse(null);
+
+        if (messageRead == null) {
+            // 읽음 기록이 없다면, 해당 채팅방에 메시지가 있는지 확인
+            return mongoMessageRepository.existsByRoomId(chatRoomId);
+        }
+
+        LocalDateTime lastReadTime = messageRead.getLastReadAt();
+        // 마지막 읽은 시간 이후에 새로운 메시지가 있는지 확인
+        return mongoMessageRepository.existsByRoomIdAndSendAtAfter(chatRoomId, lastReadTime);
+    }
+
+    // 사용자가 참여 중인 모든 채팅방의 읽지 않은 메시지 여부 확인
+    public Map<Long, Boolean> getUnreadStatusForAllChatRooms(List<Long> chatRoomIds) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Map<Long, Boolean> unreadStatusMap = new HashMap<>();
+        
+        // 사용자의 모든 읽음 기록 조회
+        List<MessageRead> messageReads = messageReadRepository.findByChatRoomIdsAndUserId(chatRoomIds, userId);
+        Map<Long, LocalDateTime> lastReadTimeMap = new HashMap<>();
+        
+        for (MessageRead messageRead : messageReads) {
+            lastReadTimeMap.put(messageRead.getChatRoom().getId(), messageRead.getLastReadAt());
+        }
+
+        for (Long chatRoomId : chatRoomIds) {
+            LocalDateTime lastReadTime = lastReadTimeMap.get(chatRoomId);
+            boolean hasUnread;
+            
+            if (lastReadTime == null) {
+                // 읽음 기록이 없다면, 해당 채팅방에 메시지가 있는지 확인
+                hasUnread = mongoMessageRepository.existsByRoomId(chatRoomId);
+            } else {
+                // 마지막 읽은 시간 이후에 새로운 메시지가 있는지 확인
+                hasUnread = mongoMessageRepository.existsByRoomIdAndSendAtAfter(chatRoomId, lastReadTime);
+            }
+            
+            unreadStatusMap.put(chatRoomId, hasUnread);
+        }
+
+        return unreadStatusMap;
+    }
+
+    // 전체 읽지 않은 메시지가 있는 채팅방이 있는지 확인 (마이페이지용)
+    public boolean hasAnyUnreadMessages() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        List<MessageRead> messageReads = messageReadRepository.findByUserId(userId);
+        
+        // 읽음 기록이 있는 채팅방들에 대해 확인
+        for (MessageRead messageRead : messageReads) {
+            Long chatRoomId = messageRead.getChatRoom().getId();
+            LocalDateTime lastReadTime = messageRead.getLastReadAt();
+            
+            if (mongoMessageRepository.existsByRoomIdAndSendAtAfter(chatRoomId, lastReadTime)) {
+                return true;
+            }
+        }
+        
+        // TODO: 읽음 기록이 없는 채팅방들도 확인해야 할 수 있음 (필요시 추가 구현)
+        
+        return false;
+    }
+}

--- a/src/main/java/com/dataury/soloJ/domain/home/dto/HomeResponse.java
+++ b/src/main/java/com/dataury/soloJ/domain/home/dto/HomeResponse.java
@@ -1,6 +1,7 @@
 package com.dataury.soloJ.domain.home.dto;
 
 import com.dataury.soloJ.domain.review.entity.status.Difficulty;
+import com.dataury.soloJ.domain.user.entity.status.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -58,5 +59,6 @@ public class HomeResponse {
         private Integer maxParticipants;
         private LocalDateTime scheduledDate;
         private String hostNickname;
+        private Gender genderRestriction;  // 채팅방 성별 제한
     }
 }

--- a/src/main/java/com/dataury/soloJ/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/dataury/soloJ/domain/mypage/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.dataury.soloJ.domain.mypage.controller;
 
 import com.dataury.soloJ.domain.chat.dto.ChatRoomListItem;
+import com.dataury.soloJ.domain.chat.service.MessageReadQueryService;
 import com.dataury.soloJ.domain.community.dto.PostResponseDto;
 import com.dataury.soloJ.domain.mypage.service.MyPageFacadeService;
 import com.dataury.soloJ.global.ApiResponse;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyPageController {
 
     private final MyPageFacadeService myPageFacadeService;
+    private final MessageReadQueryService messageReadQueryService;
 
     @GetMapping("/chatrooms")
     @Operation(summary = "사용자 동행방 목록 조회")
@@ -63,5 +65,12 @@ public class MyPageController {
 
         Pageable pageable = PageRequest.of(page, size, Sort.unsorted());
         return ApiResponse.onSuccess(myPageFacadeService.getMyCommentedPosts(pageable));
+    }
+
+    @GetMapping("/unread-messages")
+    @Operation(summary = "읽지 않은 채팅 메시지 여부 확인", description = "사용자가 읽지 않은 채팅 메시지가 있는지 확인합니다.")
+    public ApiResponse<Boolean> hasUnreadMessages() {
+        boolean hasUnread = messageReadQueryService.hasAnyUnreadMessages();
+        return ApiResponse.onSuccess(hasUnread);
     }
 }

--- a/src/main/java/com/dataury/soloJ/domain/mypage/service/MyPageFacadeService.java
+++ b/src/main/java/com/dataury/soloJ/domain/mypage/service/MyPageFacadeService.java
@@ -2,6 +2,7 @@ package com.dataury.soloJ.domain.mypage.service;
 
 import com.dataury.soloJ.domain.chat.dto.ChatRoomListItem;
 import com.dataury.soloJ.domain.chat.service.ChatRoomQueryService;
+import com.dataury.soloJ.domain.chat.service.MessageReadQueryService;
 import com.dataury.soloJ.domain.community.dto.PostResponseDto;
 import com.dataury.soloJ.domain.community.service.PostService;
 import com.dataury.soloJ.domain.community.service.ScrapService;
@@ -19,6 +20,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class MyPageFacadeService {
     private final ChatRoomQueryService chatRoomQueryService;
+    private final MessageReadQueryService messageReadQueryService;
     private final ScrapService scrapService;
     private final PostService postService;
 

--- a/src/main/java/com/dataury/soloJ/domain/user/entity/status/Gender.java
+++ b/src/main/java/com/dataury/soloJ/domain/user/entity/status/Gender.java
@@ -1,5 +1,5 @@
 package com.dataury.soloJ.domain.user.entity.status;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE, FEMALE, MIXED
 }

--- a/src/main/java/com/dataury/soloJ/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/dataury/soloJ/global/code/status/ErrorStatus.java
@@ -49,6 +49,9 @@ public enum ErrorStatus implements BaseErrorCode {
     JOINCHAT_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4003","해당 채팅방의 사용자를 찾을 수 없습니다."),
     ALREADY_JOINED_CHATROOM(HttpStatus.BAD_REQUEST,"CHAT4004","이미 참가한 채팅방입니다."),
     CHATROOM_FULL(HttpStatus.BAD_REQUEST,"CHAT4005","채팅방 최대 인원수에 도달했습니다."),
+    USER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND,"CHAT4006","사용자 프로필을 찾을 수 없습니다."),
+    GENDER_RESTRICTION_VIOLATION(HttpStatus.FORBIDDEN,"CHAT4007","해당 채팅방의 성별 제한에 맞지 않습니다."),
+    INVALID_GENDER_RESTRICTION_FOR_CREATION(HttpStatus.BAD_REQUEST,"CHAT4008","사용자 성별과 다른 성별 제한의 채팅방은 생성할 수 없습니다."),
 
 
     PAGE_BOUND_ERROR(HttpStatus.BAD_REQUEST, "PAGE4001", "페이징 번호가 적절하지 않습니다."),


### PR DESCRIPTION
## 🎋 관련 이슈

- #25 

## ⚡️ 작업동기

- 메시지 읽음처리 및 채팅방 성별 관련 로직 기능 구현

## 🔑 주요 변경사항

- 메시지 읽음처리 
- 마이페이지 메시지 읽음여부 처리
- 채팅방 성별 필드 추가
- 다른 성별일 경우 생성 불가능, 참여 불가능 

## 💡 유의사항 또는 기타

-

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!